### PR TITLE
Add candle GPT prototype modules

### DIFF
--- a/bougie_tokenizer.py
+++ b/bougie_tokenizer.py
@@ -1,0 +1,30 @@
+import numpy as np
+from typing import Tuple, Dict
+
+class CandleTokenizer:
+    """Tokenize normalized and quantized OHLCV candles."""
+
+    def __init__(self, quant: float = 1e-4, norm_factor: float = 100.0):
+        self.quant = quant
+        self.norm_factor = norm_factor
+        self.codebook: Dict[Tuple[float, ...], int] = {}
+        self.inverse_codebook: Dict[int, Tuple[float, ...]] = {}
+
+    def _normalize(self, candle: Tuple[float, float, float, float, float]) -> np.ndarray:
+        return np.array(candle, dtype=np.float32) / self.norm_factor
+
+    def _quantize(self, values: np.ndarray) -> Tuple[float, ...]:
+        return tuple(np.round(values / self.quant) * self.quant)
+
+    def encode(self, candle: Tuple[float, float, float, float, float]) -> int:
+        """Return integer token for given candle."""
+        key = self._quantize(self._normalize(candle))
+        if key not in self.codebook:
+            idx = len(self.codebook)
+            self.codebook[key] = idx
+            self.inverse_codebook[idx] = key
+        return self.codebook[key]
+
+    def decode(self, token: int) -> Tuple[float, float, float, float, float]:
+        values = np.array(self.inverse_codebook[token]) * self.norm_factor
+        return tuple(values.astype(float))

--- a/gpt_bougie_model.py
+++ b/gpt_bougie_model.py
@@ -1,0 +1,29 @@
+import torch
+from torch import nn
+from transformers import GPT2Model, GPT2Config
+
+class BougieGPT(nn.Module):
+    """Minimal GPT-style model for candle tokens with asset embeddings."""
+
+    def __init__(self, vocab_size: int, n_assets: int, hidden_size: int = 768,
+                 n_layers: int = 12, n_heads: int = 12, dropout: float = 0.1):
+        super().__init__()
+        config = GPT2Config(
+            vocab_size=vocab_size,
+            n_positions=1024,
+            n_embd=hidden_size,
+            n_layer=n_layers,
+            n_head=n_heads,
+            resid_pdrop=dropout,
+            attn_pdrop=dropout,
+        )
+        self.transformer = GPT2Model(config)
+        self.asset_emb = nn.Embedding(n_assets, hidden_size)
+        self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+
+    def forward(self, input_ids: torch.Tensor, asset_ids: torch.Tensor):
+        asset_embeddings = self.asset_emb(asset_ids).unsqueeze(1)
+        inputs_embeds = self.transformer.wte(input_ids) + asset_embeddings
+        outputs = self.transformer(inputs_embeds=inputs_embeds)
+        logits = self.lm_head(outputs.last_hidden_state)
+        return logits

--- a/market_env.py
+++ b/market_env.py
@@ -1,0 +1,39 @@
+import random
+import numpy as np
+import gymnasium as gym
+from typing import Dict, List
+
+from bougie_tokenizer import CandleTokenizer
+
+class MarketEnv(gym.Env):
+    """Sequential environment providing rewards for candle prediction."""
+
+    def __init__(self, token_sequences: Dict[int, List[int]], tokenizer: CandleTokenizer, context_len: int = 10):
+        super().__init__()
+        self.token_sequences = token_sequences
+        self.tokenizer = tokenizer
+        self.context_len = context_len
+        self.asset_ids = list(token_sequences.keys())
+        self.action_space = gym.spaces.Discrete(len(tokenizer.codebook))
+        self.observation_space = gym.spaces.MultiDiscrete([len(tokenizer.codebook)] * context_len)
+        self.reset()
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        self.asset_id = random.choice(self.asset_ids)
+        self.seq = self.token_sequences[self.asset_id]
+        self.pos = 0
+        self.done = False
+        return np.array(self.seq[: self.context_len], dtype=np.int64), {}
+
+    def step(self, action: int):
+        target = self.seq[self.pos + self.context_len]
+        pred_candle = self.tokenizer.decode(action)
+        true_candle = self.tokenizer.decode(target)
+        reward = -float(np.mean(np.abs(np.array(pred_candle) - np.array(true_candle))))
+        self.pos += 1
+        if self.pos + self.context_len >= len(self.seq) - 1:
+            self.done = True
+        obs = np.array(self.seq[self.pos : self.pos + self.context_len], dtype=np.int64)
+        info = {"asset_id": self.asset_id}
+        return obs, reward, self.done, False, info

--- a/multi_asset_dataset.py
+++ b/multi_asset_dataset.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Tuple
+import torch
+from torch.utils.data import Dataset
+
+class MultiAssetDataset(Dataset):
+    """Sliding window dataset over multiple assets."""
+
+    def __init__(self, data: Dict[int, List[int]], seq_len: int):
+        self.samples: List[Tuple[List[int], int, int]] = []
+        self.seq_len = seq_len
+        for asset_id, tokens in data.items():
+            for i in range(len(tokens) - seq_len):
+                context = tokens[i:i + seq_len]
+                target = tokens[i + seq_len]
+                self.samples.append((context, asset_id, target))
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int):
+        context, asset_id, target = self.samples[idx]
+        return (
+            torch.tensor(context, dtype=torch.long),
+            torch.tensor(asset_id, dtype=torch.long),
+            torch.tensor(target, dtype=torch.long),
+        )

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,14 @@
-agent de lecture d un mail
+# Crypto Candle GPT Prototype
+
+This repository contains a minimal implementation of a GPT-style model that works on
+quantized OHLCV candles. It includes utilities for tokenising candles, building a
+multi-asset dataset and running supervised or reinforcement learning training loops.
+
+## Modules
+
+- `bougie_tokenizer.py` – discretises and encodes full candles into integer tokens
+- `gpt_bougie_model.py` – GPT model with an additional asset embedding
+- `multi_asset_dataset.py` – sliding window dataset over token sequences
+- `market_env.py` – simple market environment producing rewards for predictions
+- `train_supervised.py` – example cross-entropy pretraining loop
+- `rl_trainer.py` – skeleton PPO training routine using stable-baselines3

--- a/rl_trainer.py
+++ b/rl_trainer.py
@@ -1,0 +1,42 @@
+"""Example PPO training loop for BougieGPT using stable-baselines3."""
+import torch
+from stable_baselines3 import PPO
+from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
+from stable_baselines3.common.policies import ActorCriticPolicy
+from stable_baselines3.common.env_util import make_vec_env
+from typing import Any
+
+from gpt_bougie_model import BougieGPT
+from market_env import MarketEnv
+
+class GPTExtractor(BaseFeaturesExtractor):
+    def __init__(self, observation_space, vocab_size: int, n_assets: int, hidden_size: int = 768):
+        super().__init__(observation_space, features_dim=hidden_size)
+        self.model = BougieGPT(vocab_size, n_assets, hidden_size=hidden_size)
+        self.features_dim = hidden_size
+
+    def forward(self, observations: torch.Tensor) -> torch.Tensor:
+        tokens = observations.long()
+        batch_size = tokens.shape[0]
+        asset_ids = torch.zeros(batch_size, dtype=torch.long, device=tokens.device)
+        outputs = self.model(tokens, asset_ids)
+        return outputs[:, -1, :]
+
+class GPTPolicy(ActorCriticPolicy):
+    def __init__(self, observation_space, action_space, lr_schedule, vocab_size: int, n_assets: int, **kwargs):
+        self.extractor = GPTExtractor(observation_space, vocab_size, n_assets)
+        super().__init__(observation_space, action_space, lr_schedule,
+                         features_extractor=self.extractor,
+                         features_extractor_class=None,
+                         features_extractor_kwargs=None,
+                         **kwargs)
+
+
+def train(env: MarketEnv, timesteps: int = 1000):
+    policy_kwargs = dict(vocab_size=len(env.tokenizer.codebook), n_assets=len(env.asset_ids))
+    model = PPO(GPTPolicy, env, policy_kwargs=policy_kwargs, verbose=1)
+    model.learn(total_timesteps=timesteps)
+    return model
+
+if __name__ == "__main__":
+    print("This module provides the train() function for PPO training.")

--- a/train_supervised.py
+++ b/train_supervised.py
@@ -1,0 +1,27 @@
+"""Simple supervised pretraining for BougieGPT."""
+import torch
+from torch.utils.data import DataLoader
+from torch import nn
+
+from gpt_bougie_model import BougieGPT
+from multi_asset_dataset import MultiAssetDataset
+
+
+def train(dataset: MultiAssetDataset, vocab_size: int, n_assets: int, epochs: int = 1, batch_size: int = 8):
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    model = BougieGPT(vocab_size=vocab_size, n_assets=n_assets)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    criterion = nn.CrossEntropyLoss()
+
+    model.train()
+    for _ in range(epochs):
+        for contexts, asset_ids, targets in dataloader:
+            logits = model(contexts, asset_ids)
+            loss = criterion(logits[:, -1, :], targets)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+    return model
+
+if __name__ == "__main__":
+    print("This module provides the train() function for supervised pretraining.")


### PR DESCRIPTION
## Summary
- implement `CandleTokenizer` for quantized OHLCV tokens
- create `BougieGPT` Transformer with asset embeddings
- build dataset and market environment helpers
- add skeleton PPO trainer and supervised training loop
- document project modules

## Testing
- `python -m py_compile bougie_tokenizer.py gpt_bougie_model.py multi_asset_dataset.py market_env.py rl_trainer.py train_supervised.py`

------
https://chatgpt.com/codex/tasks/task_e_687b53c9b71c8323b1ca7e7c89e95e27